### PR TITLE
Add SignalR chat frontend scaffolding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PeakForm</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "@microsoft/signalr": "^7.0.12",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import ChatPage from './features/chat/ChatPage';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Navbar />
+      <Routes>
+        <Route path="/chat" element={<ChatPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+const Navbar: React.FC = () => {
+  return (
+    <nav>
+      <Link to="/chat">Chat</Link>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useChat } from './hooks/useChat';
+
+const ChatPage: React.FC = () => {
+  const { messages, send } = useChat();
+  const [prompt, setPrompt] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!prompt.trim()) return;
+    send(prompt);
+    setPrompt('');
+  };
+
+  return (
+    <div>
+      <div>
+        {messages.map((m, idx) => (
+          <div key={idx} style={{ textAlign: m.sender === 'user' ? 'right' : 'left' }}>
+            <strong>{m.sender === 'user' ? 'You' : 'Assistant'}:</strong> {m.content}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit}>
+        <input value={prompt} onChange={(e) => setPrompt(e.target.value)} />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+};
+
+export default ChatPage;

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react';
+import { HubConnection } from '@microsoft/signalr';
+import { buildChatConnection, sendPrompt, subscribeToMessages } from '../../../services/chat';
+import { ChatMessage } from '../../../types/dto';
+
+export function useChat() {
+  const [connection, setConnection] = useState<HubConnection | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const assistantBuffer = useRef('');
+
+  useEffect(() => {
+    const conn = buildChatConnection();
+    setConnection(conn);
+
+    conn.start().then(() => {
+      subscribeToMessages(conn, (chunk) => {
+        assistantBuffer.current += chunk;
+        setMessages((prev) => {
+          const updated = [...prev];
+          const last = updated[updated.length - 1];
+          if (last && last.sender === 'assistant') {
+            last.content = assistantBuffer.current;
+          } else {
+            updated.push({ sender: 'assistant', content: assistantBuffer.current });
+          }
+          return updated;
+        });
+      });
+    });
+
+    return () => {
+      conn.stop();
+    };
+  }, []);
+
+  const send = async (prompt: string) => {
+    if (!connection) return;
+    assistantBuffer.current = '';
+    setMessages((prev) => [...prev, { sender: 'user', content: prompt }, { sender: 'assistant', content: '' }]);
+    await sendPrompt(connection, prompt);
+  };
+
+  return { messages, send };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/services/chat.ts
+++ b/frontend/src/services/chat.ts
@@ -1,0 +1,13 @@
+import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
+
+export function buildChatConnection(): HubConnection {
+  return new HubConnectionBuilder().withUrl('/chatHub').withAutomaticReconnect().build();
+}
+
+export async function sendPrompt(connection: HubConnection, prompt: string): Promise<void> {
+  await connection.invoke('SendPrompt', prompt);
+}
+
+export function subscribeToMessages(connection: HubConnection, handler: (message: string) => void): void {
+  connection.on('ReceiveMessage', (_user: string, message: string) => handler(message));
+}

--- a/frontend/src/types/dto.ts
+++ b/frontend/src/types/dto.ts
@@ -1,0 +1,4 @@
+export interface ChatMessage {
+  sender: 'user' | 'assistant';
+  content: string;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React frontend with Vite configuration
- add SignalR chat service, hook, and Chat UI
- wire chat route and navbar link

## Testing
- `npm install` *(fails: 403 Forbidden for @microsoft/signalr)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895037f814c832ab538a43b73514eeb